### PR TITLE
Add opt-in Safe (EIP-1271) verification for ETH payload signatures

### DIFF
--- a/ratio1/_ver.py
+++ b/ratio1/_ver.py
@@ -1,4 +1,4 @@
-__VER__ = "3.5.27"
+__VER__ = "3.5.28"
 
 if __name__ == "__main__":
   with open("pyproject.toml", "rt") as fd:

--- a/ratio1/bc/evm.py
+++ b/ratio1/bc/evm.py
@@ -532,8 +532,6 @@ class _EVMMixin:
         return False
       if not self.is_valid_eth_address(expected_signer):
         return False
-      if not hasattr(self, "web3") or self.web3 is None:
-        return False
 
       safe_address = Web3.to_checksum_address(expected_signer)
       prefix = b"\x19Ethereum Signed Message:\n" + str(len(message_hash)).encode("utf-8")

--- a/ratio1/bc/evm.py
+++ b/ratio1/bc/evm.py
@@ -473,11 +473,16 @@ class _EVMMixin:
       """
       result = None
       error = None
-      if no_hash:
-        message_hash = values[0].encode('utf-8')
-      else:
-        message_hash = self.eth_hash_message(types, values, as_hex=False)
-      signable_message = encode_defunct(primitive=message_hash)
+      message_hash = None
+      signable_message = None
+      try:
+        if no_hash:
+          message_hash = values[0].encode('utf-8')
+        else:
+          message_hash = self.eth_hash_message(types, values, as_hex=False)
+        signable_message = encode_defunct(primitive=message_hash)
+      except Exception as exc:
+        error = exc
 
       try:
         signature_bytes = bytes.fromhex(signature.removeprefix("0x"))
@@ -485,7 +490,7 @@ class _EVMMixin:
         signature_bytes = None
         error = exc
 
-      if signature_bytes is not None:
+      if signature_bytes is not None and signable_message is not None:
         try:
           recovered_address = Account.recover_message(signable_message, signature=signature_bytes)
           if expected_signer is None:
@@ -501,7 +506,12 @@ class _EVMMixin:
         except Exception as exc:
           error = exc
 
-      if result is None and expected_signer is not None and signature_bytes is not None:
+      if (
+        result is None
+        and expected_signer is not None
+        and signature_bytes is not None
+        and message_hash is not None
+      ):
         try:
           if self._eth_verify_safe_signature(
             expected_signer=expected_signer,

--- a/ratio1/bc/evm.py
+++ b/ratio1/bc/evm.py
@@ -45,6 +45,21 @@ else:
 
 
 class _EVMMixin:
+  _SAFE_SIGNATURE_MAGIC_VALUE = b"\x16\x26\xba\x7e"
+  _SAFE_SIGNATURE_ABI = [
+    {
+      "constant": True,
+      "inputs": [
+        {"name": "_hash", "type": "bytes32"},
+        {"name": "_signature", "type": "bytes"},
+      ],
+      "name": "isValidSignature",
+      "outputs": [{"name": "magicValue", "type": "bytes4"}],
+      "payable": False,
+      "stateMutability": "view",
+      "type": "function",
+    }
+  ]
 
   # EVM address methods
   if True:
@@ -426,6 +441,7 @@ class _EVMMixin:
       signature: str, 
       raise_if_error=False,
       no_hash=False,
+      expected_signer: str = None,
     ):
       """
       Verifies an EVM-compatible signature by:
@@ -444,6 +460,11 @@ class _EVMMixin:
         
       signature : str
         The signature in hex form (e.g. "0x1234abcd...").
+      
+      expected_signer : str, optional
+        If provided, verification is considered successful only for this address.
+        If EOA recovery does not match, a Safe EIP-1271 contract check is attempted
+        against this address.
 
       Returns
       -------
@@ -451,30 +472,80 @@ class _EVMMixin:
         The recovered address as a string (in checksum format), or None if verification fails.
       """
       result = None
-      try:
-        # 1) Recompute the message hash used at signing time
-        if no_hash:
-          message_hash = values[0].encode('utf-8')
-        else:
-          message_hash = self.eth_hash_message(types, values, as_hex=False)
-        signable_message = encode_defunct(primitive=message_hash)
-        
-        # 2) Convert the hex signature string into bytes
-        signature_bytes = bytes.fromhex(signature.removeprefix("0x"))
-        
-        # 3) Recover the address from the signature
-        recovered_address = Account.recover_message(signable_message, signature=signature_bytes)
-        
-        result = recovered_address
+      error = None
+      if no_hash:
+        message_hash = values[0].encode('utf-8')
+      else:
+        message_hash = self.eth_hash_message(types, values, as_hex=False)
+      signable_message = encode_defunct(primitive=message_hash)
 
+      try:
+        signature_bytes = bytes.fromhex(signature.removeprefix("0x"))
       except Exception as exc:
+        signature_bytes = None
+        error = exc
+
+      if signature_bytes is not None:
+        try:
+          recovered_address = Account.recover_message(signable_message, signature=signature_bytes)
+          if expected_signer is None:
+            result = recovered_address
+          elif recovered_address.lower() == expected_signer.lower():
+            result = recovered_address
+          else:
+            error = Exception(
+              "Recovered address {} does not match expected signer {}.".format(
+                recovered_address, expected_signer
+              )
+            )
+        except Exception as exc:
+          error = exc
+
+      if result is None and expected_signer is not None and signature_bytes is not None:
+        try:
+          if self._eth_verify_safe_signature(
+            expected_signer=expected_signer,
+            message_hash=message_hash,
+            signature_bytes=signature_bytes,
+          ):
+            result = Web3.to_checksum_address(expected_signer)
+          else:
+            error = Exception("Safe EIP-1271 signature verification failed.")
+        except Exception as exc:
+          error = exc
+
+      if result is None:
+        if error is None:
+          error = Exception("Signature verification failed.")
         if raise_if_error:
-          raise exc
-        else:
-          self.P("Signature verification failed: {}".format(exc), color='r')
-        # Any error (e.g., malformed signature, mismatch) leads to failure
-        result = None
+          raise error
+        self.P("Signature verification failed: {}".format(error), color='r')
       return result   
+
+    def _eth_verify_safe_signature(
+      self,
+      expected_signer: str,
+      message_hash: bytes,
+      signature_bytes: bytes,
+    ) -> bool:
+      if EE_VPN_IMPL:
+        return False
+      if not self.is_valid_eth_address(expected_signer):
+        return False
+      if not hasattr(self, "web3") or self.web3 is None:
+        return False
+
+      safe_address = Web3.to_checksum_address(expected_signer)
+      prefix = b"\x19Ethereum Signed Message:\n" + str(len(message_hash)).encode("utf-8")
+      safe_message_hash = keccak(prefix + message_hash)
+      contract = self.web3.eth.contract(address=safe_address, abi=self._SAFE_SIGNATURE_ABI)
+      magic_value = contract.functions.isValidSignature(safe_message_hash, signature_bytes).call()
+
+      if isinstance(magic_value, str):
+        magic_value = bytes.fromhex(magic_value.removeprefix("0x"))
+      else:
+        magic_value = bytes(magic_value)
+      return magic_value[:4] == self._SAFE_SIGNATURE_MAGIC_VALUE
          
 
 
@@ -518,6 +589,7 @@ class _EVMMixin:
       no_hash=False,
       message_prefix: str = "",
       raise_if_error=False,
+      expected_signer: str = None,
     ):
       """
       Verifies the signature of a message by checking if the recovered address matches the expected sender.
@@ -547,6 +619,7 @@ class _EVMMixin:
       values = [message_prefix + text]
       result = self.eth_verify_message_signature(
         values=values, types=types, signature=signature, no_hash=no_hash,
+        expected_signer=expected_signer,
         raise_if_error=raise_if_error
       )
       return result
@@ -607,7 +680,8 @@ class _EVMMixin:
       no_hash=False, 
       message_prefix: str = "",
       indent=0,
-      raise_if_error=False
+      raise_if_error=False,
+      verify_safe: bool = False,
     ):
       """
       Verifies the signature of a payload by checking if the recovered address matches 
@@ -630,6 +704,10 @@ class _EVMMixin:
       
       indent : int, optional
           The indentation level for the JSON string. The default is 0.
+
+      verify_safe : bool, optional
+          If True, when EOA recovery fails or mismatches, an EIP-1271 Safe
+          verification is attempted against `ETH_SENDER`. The default is False.
                   
       Returns
       -------
@@ -656,7 +734,9 @@ class _EVMMixin:
         str_data = self.safe_dict_to_json(_payload, indent=indent)
         result = self.eth_verify_text_signature(
           text=str_data, signature=signature, message_prefix=message_prefix,
-          no_hash=no_hash, raise_if_error=raise_if_error
+          no_hash=no_hash,
+          raise_if_error=raise_if_error,
+          expected_signer=sender if verify_safe else None,
         )
         if result is None or result.lower() != sender.lower():
           if raise_if_error:

--- a/tests/test_evm_safe_signature.py
+++ b/tests/test_evm_safe_signature.py
@@ -1,0 +1,163 @@
+import unittest
+from unittest import mock
+
+from eth_account import Account
+from eth_account.messages import encode_defunct
+from eth_utils import keccak
+from web3 import Web3
+
+from ratio1.bc.evm import _EVMMixin
+from ratio1.const.base import BCctbase
+
+
+class _DummyEngine(_EVMMixin):
+  def __init__(self):
+    self.web3 = mock.Mock()
+    self.messages = []
+
+  def P(self, message, **kwargs):
+    self.messages.append(message)
+
+
+class TestEthSafeSignatureVerification(unittest.TestCase):
+
+  def setUp(self):
+    self.engine = _DummyEngine()
+
+  def test_eth_verify_message_signature_recovers_eoa(self):
+    private_key = "0x" + "1" * 64
+    message = "hello-world"
+    signed = Account.sign_message(
+      encode_defunct(primitive=message.encode("utf-8")),
+      private_key=private_key,
+    )
+    signature = signed.signature.hex()
+    if not signature.startswith("0x"):
+      signature = "0x" + signature
+
+    recovered = self.engine.eth_verify_message_signature(
+      values=[message],
+      types=["string"],
+      signature=signature,
+      no_hash=True,
+    )
+
+    self.assertEqual(recovered.lower(), Account.from_key(private_key).address.lower())
+
+  def test_eth_verify_message_signature_uses_safe_fallback_on_recover_error(self):
+    safe_address = "0x" + "ab" * 20
+    message = "safe-signature-message"
+    signature = "0x" + "11" * 65
+
+    contract = mock.Mock()
+    self.engine.web3.eth.contract.return_value = contract
+    contract.functions.isValidSignature.return_value.call.return_value = b"\x16\x26\xba\x7e"
+
+    with mock.patch("ratio1.bc.evm.Account.recover_message", side_effect=Exception("recover failed")):
+      recovered = self.engine.eth_verify_message_signature(
+        values=[message],
+        types=["string"],
+        signature=signature,
+        expected_signer=safe_address,
+        no_hash=True,
+      )
+
+    expected_hash = keccak(
+      b"\x19Ethereum Signed Message:\n"
+      + str(len(message.encode("utf-8"))).encode("utf-8")
+      + message.encode("utf-8")
+    )
+    expected_sig_bytes = bytes.fromhex(signature[2:])
+
+    self.assertEqual(recovered, Web3.to_checksum_address(safe_address))
+    self.engine.web3.eth.contract.assert_called_once_with(
+      address=Web3.to_checksum_address(safe_address),
+      abi=self.engine._SAFE_SIGNATURE_ABI,
+    )
+    contract.functions.isValidSignature.assert_called_once_with(expected_hash, expected_sig_bytes)
+
+  def test_eth_verify_message_signature_uses_safe_fallback_on_recovered_mismatch(self):
+    private_key = "0x" + "2" * 64
+    message = "safe-mismatch"
+    signature = Account.sign_message(
+      encode_defunct(primitive=message.encode("utf-8")),
+      private_key=private_key,
+    ).signature.hex()
+    if not signature.startswith("0x"):
+      signature = "0x" + signature
+    safe_address = "0x" + "cd" * 20
+
+    with mock.patch.object(self.engine, "_eth_verify_safe_signature", return_value=True) as safe_check:
+      recovered = self.engine.eth_verify_message_signature(
+        values=[message],
+        types=["string"],
+        signature=signature,
+        expected_signer=safe_address,
+        no_hash=True,
+      )
+
+    self.assertEqual(recovered, Web3.to_checksum_address(safe_address))
+    safe_check.assert_called_once()
+
+  def test_eth_verify_message_signature_returns_none_when_safe_fallback_fails(self):
+    private_key = "0x" + "3" * 64
+    message = "safe-fail"
+    signature = Account.sign_message(
+      encode_defunct(primitive=message.encode("utf-8")),
+      private_key=private_key,
+    ).signature.hex()
+    if not signature.startswith("0x"):
+      signature = "0x" + signature
+    safe_address = "0x" + "ef" * 20
+
+    with mock.patch.object(self.engine, "_eth_verify_safe_signature", return_value=False):
+      recovered = self.engine.eth_verify_message_signature(
+        values=[message],
+        types=["string"],
+        signature=signature,
+        expected_signer=safe_address,
+        no_hash=True,
+      )
+
+    self.assertIsNone(recovered)
+
+  def test_eth_verify_payload_signature_default_does_not_pass_expected_signer(self):
+    self.engine.safe_dict_to_json = lambda payload, indent=0: "payload-json"
+    self.engine.is_valid_eth_address = lambda address: True
+    payload = {
+      BCctbase.ETH_SENDER: "0x" + "ab" * 20,
+      BCctbase.ETH_SIGN: "0x" + "11" * 65,
+      "k": "v",
+    }
+
+    with mock.patch.object(self.engine, "eth_verify_text_signature", return_value=payload[BCctbase.ETH_SENDER]) as verify_text:
+      result = self.engine.eth_verify_payload_signature(payload=payload, no_hash=True)
+
+    self.assertEqual(result, payload[BCctbase.ETH_SENDER])
+    self.assertIsNone(verify_text.call_args.kwargs["expected_signer"])
+
+  def test_eth_verify_payload_signature_verify_safe_passes_expected_signer(self):
+    self.engine.safe_dict_to_json = lambda payload, indent=0: "payload-json"
+    self.engine.is_valid_eth_address = lambda address: True
+    payload = {
+      BCctbase.ETH_SENDER: "0x" + "cd" * 20,
+      BCctbase.ETH_SIGN: "0x" + "22" * 65,
+      "k": "v",
+    }
+
+    with mock.patch.object(self.engine, "eth_verify_text_signature", return_value=payload[BCctbase.ETH_SENDER]) as verify_text:
+      result = self.engine.eth_verify_payload_signature(
+        payload=payload,
+        no_hash=True,
+        verify_safe=True,
+      )
+
+    self.assertEqual(result, payload[BCctbase.ETH_SENDER])
+    self.assertEqual(
+      verify_text.call_args.kwargs["expected_signer"].lower(),
+      payload[BCctbase.ETH_SENDER].lower(),
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- add Safe (EIP-1271) verification fallback to EVM signature verification
- keep payload verification backward-compatible by making Safe verification opt-in via `verify_safe=False` default
- add tests for EOA verification, Safe fallback, and verify_safe opt-in behavior

## Validation
- python -m unittest tests.test_base_logger_packages tests.test_netmon_payload tests.test_evm_safe_signature

## Notes
- this keeps existing callers behavior unchanged unless `verify_safe=True` is explicitly passed
