### PR TITLE
Sign packed availability claim payloads

### DIFF
--- a/ratio1/_ver.py
+++ b/ratio1/_ver.py
@@ -1,4 +1,4 @@
-__VER__ = "3.5.37"
+__VER__ = "3.5.38"
 
 if __name__ == "__main__":
   with open("pyproject.toml", "rt") as fd:

--- a/ratio1/bc/evm.py
+++ b/ratio1/bc/evm.py
@@ -756,6 +756,31 @@ class _EVMMixin:
       return result
       
       
+    @staticmethod
+    def pack_epoch_availabilities(epochs_vals):
+      """
+      Pack per-epoch availability values into the compact bytes payload used by
+      ND/MND reward claim signatures.
+
+      Parameters
+      ----------
+      epochs_vals : list of int
+          Availability values, each in the inclusive range [0, 255].
+
+      Returns
+      -------
+      str
+          Hex string containing one byte per availability value.
+      """
+      packed = bytearray()
+      for val in epochs_vals:
+        int_val = int(val)
+        if int_val < 0 or int_val > 255:
+          raise ValueError(f"Invalid epoch availability value: {val}")
+        packed.append(int_val)
+      return "0x" + packed.hex()
+
+
     def eth_sign_node_epochs(
       self, 
       node, 
@@ -777,6 +802,14 @@ class _EVMMixin:
           
       epochs_vals : list of int
           The values for each epoch.
+
+      Notes
+      -----
+      The signed EVM payload is compact and uses
+      ``node, from_epoch, to_epoch, packed_availabilities``. Epoch ids are
+      still accepted here so callers can keep using the natural oracle range
+      shape while the resulting signature matches the ND/MND packed claim
+      contract payload.
           
       signature_only : bool, optional
           Whether to return only the signature. The default is True.
@@ -789,12 +822,32 @@ class _EVMMixin:
       str
           The signature of the message.
       """
+      if len(epochs) != len(epochs_vals):
+        raise ValueError("Epochs and availability values must have the same length.")
+      if len(epochs) == 0:
+        raise ValueError("At least one epoch is required for signing.")
+      from_epoch = int(epochs[0])
+      to_epoch = int(epochs[-1])
+      packed_availabilities = self.pack_epoch_availabilities(epochs_vals)
       if use_evm_node_addr:
-        types = [ETHVarTypes.ETH_ADDR, ETHVarTypes.ETH_ARRAY_INT, ETHVarTypes.ETH_ARRAY_INT]  
+        types = [
+          ETHVarTypes.ETH_ADDR,
+          ETHVarTypes.ETH_INT,
+          ETHVarTypes.ETH_INT,
+          ETHVarTypes.ETH_BYTES,
+        ]
       else:
-        types = [ETHVarTypes.ETH_STR, ETHVarTypes.ETH_ARRAY_INT, ETHVarTypes.ETH_ARRAY_INT]
-      values = [node, epochs, epochs_vals]
+        types = [
+          ETHVarTypes.ETH_STR,
+          ETHVarTypes.ETH_INT,
+          ETHVarTypes.ETH_INT,
+          ETHVarTypes.ETH_BYTES,
+        ]
+      values = [node, from_epoch, to_epoch, packed_availabilities]
       result = self.eth_sign_message(types, values)
+      result["from_epoch"] = from_epoch
+      result["to_epoch"] = to_epoch
+      result["packed_availabilities"] = packed_availabilities
       if signature_only:
         return result["signature"]
       return result

--- a/ratio1/bc/evm.py
+++ b/ratio1/bc/evm.py
@@ -781,6 +781,47 @@ class _EVMMixin:
       return "0x" + packed.hex()
 
 
+    @staticmethod
+    def validate_epoch_availability_range(epochs, epochs_vals):
+      """
+      Validate and normalize the contiguous epoch range used for packed
+      availability signatures.
+
+      Parameters
+      ----------
+      epochs : list of int
+          Epoch identifiers. They must be sorted, contiguous, and gap-free.
+
+      epochs_vals : list of int
+          Availability values corresponding positionally to ``epochs``.
+
+      Returns
+      -------
+      tuple
+          The normalized ``from_epoch`` and ``to_epoch`` values.
+      """
+      if len(epochs) != len(epochs_vals):
+        raise ValueError("Epochs and availability values must have the same length.")
+      if len(epochs) == 0:
+        raise ValueError("At least one epoch is required for signing.")
+
+      normalized_epochs = [int(epoch) for epoch in epochs]
+      from_epoch = normalized_epochs[0]
+      to_epoch = normalized_epochs[-1]
+      expected_len = to_epoch - from_epoch + 1
+      if expected_len != len(epochs_vals):
+        raise ValueError(
+          "Epochs must form a contiguous range matching the availability values."
+        )
+      for index, epoch in enumerate(normalized_epochs):
+        expected_epoch = from_epoch + index
+        if epoch != expected_epoch:
+          raise ValueError(
+            "Epochs must be sorted, contiguous, and gap-free for packed availability signing."
+          )
+      return from_epoch, to_epoch
+
+
     def eth_sign_node_epochs(
       self, 
       node, 
@@ -822,12 +863,7 @@ class _EVMMixin:
       str
           The signature of the message.
       """
-      if len(epochs) != len(epochs_vals):
-        raise ValueError("Epochs and availability values must have the same length.")
-      if len(epochs) == 0:
-        raise ValueError("At least one epoch is required for signing.")
-      from_epoch = int(epochs[0])
-      to_epoch = int(epochs[-1])
+      from_epoch, to_epoch = self.validate_epoch_availability_range(epochs, epochs_vals)
       packed_availabilities = self.pack_epoch_availabilities(epochs_vals)
       if use_evm_node_addr:
         types = [

--- a/ratio1/const/base.py
+++ b/ratio1/const/base.py
@@ -12,6 +12,7 @@ SB_ID = 'SB_ID'  # change to SB_ID = EE_ID post mod from sb to ee
 class ETHVarTypes:
   ETH_ADDR = 'address'
   ETH_INT = 'uint256'
+  ETH_BYTES = 'bytes'
   ETH_STR = 'string'
   ETH_ARRAY_INT = 'uint256[]'
   ETH_ARRAY_STR = 'string[]'

--- a/ratio1/utils/oracle_sync/oracle_tester.py
+++ b/ratio1/utils/oracle_sync/oracle_tester.py
@@ -118,6 +118,19 @@ class OracleTester:
         f"\t{self.node_addr_to_alias.get(node_addr)} ({node_addr}): {freq}"
         for node_addr, freq in freq_dict.items()
       ])
+
+    @staticmethod
+    def pack_epoch_availabilities(epoch_vals):
+      """
+      Pack availability values exactly like the reward claim payload expects.
+      """
+      packed = bytearray()
+      for val in epoch_vals or []:
+        int_val = int(val)
+        if int_val < 0 or int_val > 255:
+          raise ValueError(f"Invalid epoch availability value: {val}")
+        packed.append(int_val)
+      return "0x" + packed.hex()
   """END UTILS"""
 
   """RESPONSE HANDLING"""
@@ -149,6 +162,47 @@ class OracleTester:
         current_cert.append(dict_certainty.get(str(epoch_id), 0))
       # endfor epochs
       return current_epochs, current_avails, current_cert, is_valid, min_certainty_prc
+
+    def compute_claim_payload_data(self, result: dict, epochs: list, avails: list, is_valid: bool):
+      """
+      Extract and validate compact reward claim fields returned by the oracle.
+      """
+      from_epoch = result.get("from_epoch")
+      to_epoch = result.get("to_epoch")
+      packed_availabilities = result.get("packed_availabilities")
+      eth_signatures = result.get("eth_signatures")
+      eth_addresses = result.get("eth_addresses")
+      eth_signed_data = result.get("eth_signed_data", {}).get("input")
+
+      errors = []
+      expected_from_epoch = epochs[0] if len(epochs) > 0 else None
+      expected_to_epoch = epochs[-1] if len(epochs) > 0 else None
+      expected_packed_availabilities = self.pack_epoch_availabilities(avails)
+
+      if from_epoch != expected_from_epoch:
+        errors.append(f"from_epoch: {from_epoch} != {expected_from_epoch}")
+      if to_epoch != expected_to_epoch:
+        errors.append(f"to_epoch: {to_epoch} != {expected_to_epoch}")
+      if is_valid:
+        if packed_availabilities != expected_packed_availabilities:
+          errors.append(
+            f"packed_availabilities: {packed_availabilities} != {expected_packed_availabilities}"
+          )
+        if eth_signed_data != ["address", "uint256", "uint256", "bytes"]:
+          errors.append(f"eth_signed_data: {eth_signed_data} != ['address', 'uint256', 'uint256', 'bytes']")
+      if eth_signatures is not None and not isinstance(eth_signatures, list):
+        errors.append(f"eth_signatures is not a list: {type(eth_signatures)}")
+      if eth_addresses is not None and not isinstance(eth_addresses, list):
+        errors.append(f"eth_addresses is not a list: {type(eth_addresses)}")
+
+      return {
+        "from_epoch": from_epoch,
+        "to_epoch": to_epoch,
+        "packed_availabilities": packed_availabilities,
+        "eth_signatures": eth_signatures,
+        "eth_addresses": eth_addresses,
+        "eth_signed_data": eth_signed_data,
+      }, errors
 
     def handle_server_data(
         self, oracle_stats_dict: dict,
@@ -187,6 +241,13 @@ class OracleTester:
       stats_certs = current_stats.get("certs", None)
       stats_is_valid = current_stats.get("is_valid", None)
       stats_min_certainty_prc = current_stats.get("min_certainty_prc", None)
+      current_claim_payload, claim_payload_errors = self.compute_claim_payload_data(
+        result=result,
+        epochs=current_epochs,
+        avails=current_avails,
+        is_valid=is_valid
+      )
+      stats_claim_payload = current_stats.get("claim_payload", None)
       mismatches = []
       if stats_epochs is not None and current_epochs != stats_epochs:
         mismatches.append(f"epochs: {current_epochs} != {stats_epochs}")
@@ -203,6 +264,10 @@ class OracleTester:
       if stats_min_certainty_prc is not None and min_certainty_prc != stats_min_certainty_prc:
         mismatches.append(f"min_certainty_prc: {min_certainty_prc} != {stats_min_certainty_prc}")
       # endif check for mismatch
+      if stats_claim_payload is not None and current_claim_payload != stats_claim_payload:
+        mismatches.append(f"claim_payload: {current_claim_payload} != {stats_claim_payload}")
+      # endif check for mismatch
+      mismatches.extend(claim_payload_errors)
 
       if len(mismatches) > 0:
         current_stats["errors"].append(f"Round {self.request_rounds}: {', '.join(mismatches)}")
@@ -218,6 +283,8 @@ class OracleTester:
           current_stats["is_valid"] = is_valid
         if stats_min_certainty_prc is None:
           current_stats["min_certainty_prc"] = min_certainty_prc
+        if stats_claim_payload is None:
+          current_stats["claim_payload"] = current_claim_payload
       # endif valid data received
       return
 
@@ -475,6 +542,10 @@ class OracleTester:
       msg += f'  Oracle address:  {oracle_addr}\n'
       msg += f'  Oracle ETH addr: {oracle_addr_eth}\n'
       msg += f'  Oracle alias:    {oracle_alias}\n'
+      claim_payload = sender_data.get("claim_payload", {})
+      msg += f'  Claim range:     {claim_payload.get("from_epoch")} -> {claim_payload.get("to_epoch")}\n'
+      msg += f'  Packed bytes:    {len((claim_payload.get("packed_availabilities") or "0x")[2:]) // 2}\n'
+      msg += f'  ETH signatures:  {len(claim_payload.get("eth_signatures") or [])}\n'
       msg += f'  Oracle responses:\n'
       epochs = sender_data.get("epochs", None)
       avails = sender_data.get("avails", None)
@@ -525,6 +596,10 @@ class OracleTester:
           curr_msg += f'\t\t ETH Addr:  {sender_data["eth_addr"]}\n'
           curr_msg += f'\t\t Alias:     {sender_data["alias"]}\n'
           curr_msg += f'\t\t Responses: {frequencies.get(sender, 0)}\n'
+          claim_payload = sender_data.get("claim_payload", {})
+          curr_msg += f'\t\t Claim:     {claim_payload.get("from_epoch")} -> {claim_payload.get("to_epoch")}\n'
+          curr_msg += f'\t\t Packed:    {len((claim_payload.get("packed_availabilities") or "0x")[2:]) // 2} bytes\n'
+          curr_msg += f'\t\t Sigs:      {len(claim_payload.get("eth_signatures") or [])}\n'
           curr_msg += f'\t\t Epochs:    {str_epochs}\n'
           curr_msg += f'\t\t Avails:    {str_avails}\n'
           curr_msg += f'\t\t Certainty: {str_certs}\n'

--- a/tests/test_evm_epoch_signing.py
+++ b/tests/test_evm_epoch_signing.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest import mock
+
+from ratio1.bc.evm import _EVMMixin
+from ratio1.const.base import ETHVarTypes
+
+
+class _DummyEngine(_EVMMixin):
+  pass
+
+
+class TestEthNodeEpochSigning(unittest.TestCase):
+
+  def setUp(self):
+    self.engine = _DummyEngine()
+
+  def test_eth_sign_node_epochs_signs_contiguous_packed_range(self):
+    self.engine.eth_sign_message = mock.Mock(
+      return_value={
+        "signature": "0x" + "11" * 65,
+        "eth_signed_data": [
+          ETHVarTypes.ETH_ADDR,
+          ETHVarTypes.ETH_INT,
+          ETHVarTypes.ETH_INT,
+          ETHVarTypes.ETH_BYTES,
+        ],
+      }
+    )
+
+    result = self.engine.eth_sign_node_epochs(
+      node="0x000000000000000000000000000000000000dEaD",
+      epochs=[245, 246, 247],
+      epochs_vals=[1, 2, 255],
+      signature_only=False,
+    )
+
+    self.assertEqual(result["from_epoch"], 245)
+    self.assertEqual(result["to_epoch"], 247)
+    self.assertEqual(result["packed_availabilities"], "0x0102ff")
+    self.engine.eth_sign_message.assert_called_once_with(
+      [
+        ETHVarTypes.ETH_ADDR,
+        ETHVarTypes.ETH_INT,
+        ETHVarTypes.ETH_INT,
+        ETHVarTypes.ETH_BYTES,
+      ],
+      ["0x000000000000000000000000000000000000dEaD", 245, 247, "0x0102ff"],
+    )
+
+  def test_eth_sign_node_epochs_rejects_gapped_epochs(self):
+    with self.assertRaisesRegex(ValueError, "contiguous"):
+      self.engine.eth_sign_node_epochs(
+        node="0x000000000000000000000000000000000000dEaD",
+        epochs=[245, 247, 248],
+        epochs_vals=[1, 2, 3],
+      )
+
+  def test_eth_sign_node_epochs_rejects_unsorted_epochs(self):
+    with self.assertRaisesRegex(ValueError, "contiguous"):
+      self.engine.eth_sign_node_epochs(
+        node="0x000000000000000000000000000000000000dEaD",
+        epochs=[246, 245, 247],
+        epochs_vals=[1, 2, 3],
+      )
+
+  def test_eth_sign_node_epochs_rejects_mismatched_epoch_values(self):
+    with self.assertRaisesRegex(ValueError, "same length"):
+      self.engine.eth_sign_node_epochs(
+        node="0x000000000000000000000000000000000000dEaD",
+        epochs=[245, 246, 247],
+        epochs_vals=[1, 2],
+      )
+
+  def test_eth_sign_node_epochs_rejects_invalid_availability_byte(self):
+    with self.assertRaisesRegex(ValueError, "Invalid epoch availability"):
+      self.engine.eth_sign_node_epochs(
+        node="0x000000000000000000000000000000000000dEaD",
+        epochs=[245, 246, 247],
+        epochs_vals=[1, 256, 3],
+      )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/xperimental/eth/eth_sign.py
+++ b/xperimental/eth/eth_sign.py
@@ -34,16 +34,18 @@ if __name__ == '__main__' :
   l.P("Node: {}\nNode Eth: {}".format(node, node_eth))
   epochs = [245, 246, 247, 248, 249, 250]
   epochs_vals = [124, 37, 30, 6, 19, 4]
+  from_epoch, to_epoch = eng1.validate_epoch_availability_range(epochs, epochs_vals)
+  packed_availabilities = eng1.pack_epoch_availabilities(epochs_vals)
   USE_ETH_ADDR = True
   
   if USE_ETH_ADDR:  
-    types = ["address", "uint256[]", "uint256[]"]
+    types = ["address", "uint256", "uint256", "bytes"]
     node_data = node_eth
   else:
-    types = ["string", "uint256[]", "uint256[]"]
+    types = ["string", "uint256", "uint256", "bytes"]
     node_data = node
     
-  values = [node_data, epochs, epochs_vals]
+  values = [node_data, from_epoch, to_epoch, packed_availabilities]
   
  
   s2 = eng1.eth_sign_message(types, values)
@@ -55,18 +57,21 @@ if __name__ == '__main__' :
   l.P(f"Results:\n  Signature: {eth_signature}\n  Inputs: {inputs}")
   
   # check if the signature is valid
+  invalid_packed_availabilities = eng2.pack_epoch_availabilities(
+    [124, 37, 30, 6, 19, 1]
+  )
   sender = eng2.eth_check_signature(
-    values=[node_data, epochs, [124, 37, 30, 6, 19, 1]],
+    values=[node_data, from_epoch, to_epoch, invalid_packed_availabilities],
     types=types,
     signature=eth_signature,
   )
   valid = sender == eng1.eth_address
-  l.P(f"Signature from {sender} {'vali' if valid else 'invalid'}", color='g' if valid else 'r')
+  l.P(f"Signature from {sender} {'valid' if valid else 'invalid'}", color='g' if valid else 'r')
   
   sender = eng2.eth_check_signature(
-    values=[node_data, epochs, epochs_vals],
+    values=values,
     types=types,
     signature=eth_signature,
   )
   valid = sender == eng1.eth_address
-  l.P(f"Signature from {sender} {'valid' if valid else 'invalid'}", color='g' if valid else 'r')  
+  l.P(f"Signature from {sender} {'valid' if valid else 'invalid'}", color='g' if valid else 'r')


### PR DESCRIPTION
## Summary
- Add bytes support to EVM signing type constants.
- Pack one availability byte per epoch for ND/MND claim signatures.
- Sign node, from_epoch, to_epoch, and packed_availabilities while returning the compact fields to callers.

## Validation
- python -m compileall ratio1