### PR TITLE
[codex] Add compact canonical JSON hashing helper

### DIFF
--- a/ratio1/_ver.py
+++ b/ratio1/_ver.py
@@ -1,4 +1,4 @@
-__VER__ = "3.5.40"
+__VER__ = "3.5.41"
 
 if __name__ == "__main__":
   with open("pyproject.toml", "rt") as fd:

--- a/ratio1/bc/base.py
+++ b/ratio1/bc/base.py
@@ -113,6 +113,7 @@ def compact_canonical_json(value):
       serialized_value = compact_canonical_json(value[key])
       if serialized_value is None:
         continue
+      # JS object keys are strings; json.dumps then quotes and escapes the key.
       serialized_key = json.dumps(str(key), ensure_ascii=False, separators=(",", ":"))
       entries.append("{}:{}".format(serialized_key, serialized_value))
     return "{{{}}}".format(",".join(entries))

--- a/ratio1/bc/base.py
+++ b/ratio1/bc/base.py
@@ -81,6 +81,78 @@ def replace_nan_inf(data, inplace=False):
         current[key] = None
   return d 
 
+
+def compact_canonical_json(value):
+  """
+  Serialize a value as compact canonical JSON for wallet-safe request hashes.
+
+  Parameters
+  ----------
+  value : Any
+      JSON-compatible value to serialize.
+
+  Returns
+  -------
+  str or None
+      Compact canonical JSON string, or None when the value cannot be
+      represented in the JavaScript Deeploy canonicalization contract.
+  """
+  if value is None:
+    return "null"
+
+  if isinstance(value, list):
+    items = []
+    for item in value:
+      serialized_item = compact_canonical_json(item)
+      items.append(serialized_item if serialized_item is not None else "null")
+    return "[{}]".format(",".join(items))
+
+  if isinstance(value, dict):
+    entries = []
+    for key in sorted(value.keys(), key=lambda item: str(item)):
+      serialized_value = compact_canonical_json(value[key])
+      if serialized_value is None:
+        continue
+      serialized_key = json.dumps(str(key), ensure_ascii=False, separators=(",", ":"))
+      entries.append("{}:{}".format(serialized_key, serialized_value))
+    return "{{{}}}".format(",".join(entries))
+
+  if isinstance(value, float) and (np.isnan(value) or np.isinf(value)):
+    return "null"
+
+  try:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), allow_nan=False)
+  except (TypeError, ValueError):
+    return None
+
+
+def compact_canonical_sha256(value, excluded_keys=None):
+  """
+  Hash a compact-canonical JSON value with SHA-256.
+
+  Parameters
+  ----------
+  value : Any
+      JSON-compatible value to serialize and hash.
+  excluded_keys : set[str], optional
+      Top-level keys to omit before serializing a dictionary payload.
+
+  Returns
+  -------
+  str
+      Lowercase hexadecimal SHA-256 digest.
+  """
+  if excluded_keys is not None and isinstance(value, dict):
+    value = {
+      key: item
+      for key, item in value.items()
+      if key not in excluded_keys
+    }
+  serialized = compact_canonical_json(value)
+  if serialized is None:
+    serialized = "null"
+  return sha256(serialized.encode("utf-8")).hexdigest()
+
 class _SimpleJsonEncoder(json.JSONEncoder):
   """
   Used to help jsonify numpy arrays or lists that contain numpy data types.

--- a/tests/test_compact_canonical_json.py
+++ b/tests/test_compact_canonical_json.py
@@ -1,0 +1,78 @@
+import unittest
+
+from ratio1.bc.base import compact_canonical_json, compact_canonical_sha256
+from ratio1.const.base import BCctbase
+
+
+class TestCompactCanonicalJson(unittest.TestCase):
+
+  def test_compact_canonical_json_sorts_keys_and_preserves_unicode(self):
+    value = {
+      "z": [2, None],
+      "a": {
+        "city": "Iași",
+        "greeting": "bună ziua",
+      },
+    }
+
+    self.assertEqual(
+      compact_canonical_json(value),
+      '{"a":{"city":"Iași","greeting":"bună ziua"},"z":[2,null]}',
+    )
+
+  def test_compact_canonical_sha256_matches_deeploy_dapp_fixture(self):
+    payload = {
+      "nonce": "0xabc",
+      "app_alias": "münchen_api",
+      "target_nodes": ["0xai_node_a", "0xai_node_b"],
+      "target_nodes_count": 0,
+      "plugins": [
+        {
+          "plugin_signature": "WORKER_APP_RUNNER",
+          "plugin_name": "api",
+          "ENV": {"GREETING": "bună ziua"},
+          "DYNAMIC_ENV": {
+            "API_URL": [
+              {"type": "static", "value": "https://"},
+              {"type": "shmem", "path": ["web", "HOST_PORT"]},
+            ],
+          },
+        },
+        {
+          "plugin_signature": "EDGE_NODE_API_TEST",
+          "plugin_name": "probe",
+        },
+      ],
+      "pipeline_params": {
+        "labels": {"city": "Iași"},
+      },
+      "address": "remove-me",
+      "signature": "remove-me",
+      BCctbase.SIGN: "remove-me",
+      BCctbase.SENDER: "remove-me",
+      BCctbase.HASH: "remove-me",
+      BCctbase.SIGN_CANON_V: "remove-me",
+      BCctbase.ETH_SIGN: "remove-me",
+      BCctbase.ETH_SENDER: "remove-me",
+    }
+
+    self.assertEqual(
+      compact_canonical_sha256(
+        payload,
+        excluded_keys={
+          "address",
+          "signature",
+          BCctbase.SIGN,
+          BCctbase.SENDER,
+          BCctbase.HASH,
+          BCctbase.SIGN_CANON_V,
+          BCctbase.ETH_SIGN,
+          BCctbase.ETH_SENDER,
+        },
+      ),
+      "12169fe2f1a33373ba651d14318eb18d3239c0148a0d601de9f4ce3be9d2dded",
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/test_compact_canonical_json.py
+++ b/tests/test_compact_canonical_json.py
@@ -20,6 +20,30 @@ class TestCompactCanonicalJson(unittest.TestCase):
       '{"a":{"city":"Iași","greeting":"bună ziua"},"z":[2,null]}',
     )
 
+  def test_compact_canonical_json_stringifies_and_escapes_object_keys(self):
+    value = {
+      2: "two",
+      'a"b\n': "escaped",
+    }
+
+    self.assertEqual(
+      compact_canonical_json(value),
+      '{"2":"two","a\\"b\\n":"escaped"}',
+    )
+
+  def test_compact_canonical_json_handles_unsupported_values_like_javascript(self):
+    unsupported = object()
+
+    self.assertEqual(compact_canonical_json(unsupported), None)
+    self.assertEqual(
+      compact_canonical_json({
+        "keep": 1,
+        "skip": unsupported,
+        "items": [unsupported],
+      }),
+      '{"items":[null],"keep":1}',
+    )
+
   def test_compact_canonical_sha256_matches_deeploy_dapp_fixture(self):
     payload = {
       "nonce": "0xabc",


### PR DESCRIPTION
## Summary
- Adds `compact_canonical_json` and `compact_canonical_sha256` helpers in `ratio1.bc.base`.
- Adds tests pinned to the Deeploy dApp reference fixture and expected SHA-256 hash.

## Why
Deeploy v3 hash signing needs a shared SDK-side helper for byte-stable compact payload hashes across clients and server-side verification.

## Verification
- `python3 -m compileall ratio1/bc/base.py tests/test_compact_canonical_json.py` passed.
- `python3 -B -m unittest tests.test_compact_canonical_json` passed.