### PR TITLE
feat: support MQTT channel QoS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ratio1"
-version = "3.5.41"
+version = "3.5.43"
 authors = [
   { name="Andrei Ionut Damian", email="andrei.damian@ratio1.ai" },
   { name="Cristan Bleotiu", email="cristian.bleotiu@ratio1.ai" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ratio1"
-version = "3.5.30"
+version = "3.5.41"
 authors = [
   { name="Andrei Ionut Damian", email="andrei.damian@ratio1.ai" },
   { name="Cristan Bleotiu", email="cristian.bleotiu@ratio1.ai" },

--- a/ratio1/_ver.py
+++ b/ratio1/_ver.py
@@ -1,4 +1,4 @@
-__VER__ = "3.5.43"
+__VER__ = "3.5.44"
 
 if __name__ == "__main__":
   with open("pyproject.toml", "rt") as fd:

--- a/ratio1/base/generic_session.py
+++ b/ratio1/base/generic_session.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 
 from collections import deque, OrderedDict, defaultdict
+from copy import deepcopy
 from datetime import datetime as dt
 from threading import Lock, Thread
 from time import sleep
@@ -248,7 +249,7 @@ class GenericSession(BaseDecentrAIObject):
     self.__at_least_a_netmon_received = False
     
     # TODO: maybe read config from file?
-    self._config = {**self.default_config, **config}
+    self._config = {**deepcopy(self.default_config), **deepcopy(config)}
     
     
     
@@ -1648,6 +1649,32 @@ class GenericSession(BaseDecentrAIObject):
         #end if
       #end name is None      
       return self.__user_config_loaded
+
+    def __env_qos(self, *keys):
+      value = next((os.getenv(key) for key in keys if os.getenv(key) not in [None, ""]), None)
+      if value is None:
+        return None
+      value = int(value)
+      if value not in [0, 1, 2]:
+        raise ValueError(f"Invalid MQTT QoS {value}. Expected one of 0, 1, 2.")
+      return value
+
+    def __apply_channel_qos_from_env(self):
+      qos_overrides = [
+        ("CTRL_CHANNEL", self.__env_qos("EE_MQTT_HEARTBEAT_QOS", "MQTT_HEARTBEAT_QOS")),
+        ("CONFIG_CHANNEL", self.__env_qos("EE_MQTT_COMMAND_QOS", "MQTT_COMMAND_QOS")),
+      ]
+      for channel_name, qos in qos_overrides:
+        if qos is None:
+          continue
+        channel_cfg = self._config.get(channel_name)
+        if not isinstance(channel_cfg, dict):
+          raise ValueError(f"Cannot set QoS for missing MQTT channel '{channel_name}'")
+        # Keep SDK-generated commands aligned with edge-node rollout knobs. The
+        # heartbeat/command meaning is attached to the MQTT topic, not the legacy
+        # communicator name that happens to publish or receive it.
+        channel_cfg[comm_ct.QOS] = qos
+      return
     
     def __fill_config(self, host, port, user, pwd, secured, subtopic):
       """
@@ -1807,6 +1834,7 @@ class GenericSession(BaseDecentrAIObject):
       if disable_addressed_payload_subs is not None:
         self._config[comm_ct.DISABLE_ADDRESSED_PAYLOAD_SUBS] = str(disable_addressed_payload_subs).strip().upper() in ['TRUE', '1', 'YES']
 
+      self.__apply_channel_qos_from_env()
       self._config.setdefault(comm_ct.EE_ID, self.name)
       self._config.setdefault(comm_ct.EE_ADDR, self.bc_engine.address)
 

--- a/ratio1/comm/base_comm_wrapper.py
+++ b/ratio1/comm/base_comm_wrapper.py
@@ -132,6 +132,35 @@ class BaseCommWrapper(object):
   def cfg_qos(self):
     return self._config[COMMS.QOS]
 
+  def _normalize_qos(self, qos):
+    """
+    Return a validated MQTT QoS integer.
+
+    Channel-level QoS values can arrive from JSON/env processing as strings.
+    Keep validation close to the transport wrapper so bad rollout values fail
+    before silently changing delivery guarantees.
+    """
+    qos = int(qos)
+    if qos not in [0, 1, 2]:
+      raise ValueError("Invalid MQTT QoS {}. Expected one of 0, 1, 2.".format(qos))
+    return qos
+
+  def get_channel_qos(self, channel_name=None, channel_def=None):
+    """
+    Return effective QoS for a channel.
+
+    A channel-specific ``QOS`` lets heartbeats and commands use different MQTT
+    delivery guarantees while existing configs continue to inherit top-level
+    ``QOS`` unchanged.
+    """
+    if channel_def is None and channel_name is not None:
+      channel_def = self._config.get(channel_name, {})
+    if not isinstance(channel_def, dict):
+      channel_def = {}
+    if COMMS.QOS in channel_def:
+      return self._normalize_qos(channel_def[COMMS.QOS])
+    return self._normalize_qos(self.cfg_qos)
+
   @property
   def cfg_cert_path(self):
     return self._config.get(COMMS.CERT_PATH)

--- a/ratio1/comm/mqtt_wrapper.py
+++ b/ratio1/comm/mqtt_wrapper.py
@@ -365,43 +365,59 @@ class MQTTWrapper(BaseCommWrapper):
   def subscribe(self, max_retries=5):
 
     if self.recv_channel_name is None:
-      return
+      return {
+        'has_connection': True,
+        'msg': 'MQTT receive disabled for this communicator.',
+        'msg_type': PAYLOAD_CT.STATUS_TYPE.STATUS_NORMAL,
+      }
 
-    nr_retry = 1
     has_connection = True
-    exception = None
+    failure_msg = None
     channel_def = self.get_recv_channel_def()
     lst_topics = channel_def[COMMS.TOPIC]
+    qos = self.get_channel_qos(channel_def=channel_def)
     for topic in lst_topics:
+      nr_retry = 1
       current_topic_connection = False
+      exception = None
       while nr_retry <= max_retries:
         try:
           if self._mqttc is not None:
-            self._mqttc.subscribe(
+            subscribe_result = self._mqttc.subscribe(
               topic=topic,
-              qos=self.cfg_qos
+              qos=qos
             )
-            current_topic_connection = True
+            result_code = subscribe_result[0] if isinstance(subscribe_result, tuple) else None
+            if result_code in (None, mqtt.MQTT_ERR_SUCCESS):
+              current_topic_connection = True
+            else:
+              exception = "MQTT client returned subscribe rc={}".format(result_code)
           else:
-            has_connection = False
+            exception = "MQTT client is not initialized"
         except Exception as e:
-          has_connection = False
           exception = e
 
         if current_topic_connection:
           break
 
-        sleep(1)
+        if nr_retry < max_retries:
+          sleep(1)
         nr_retry += 1
       # endwhile
 
       if current_topic_connection:
-        msg = "MQTT (Paho) subscribed to topic '{}' (QoS={})".format(topic, self.cfg_qos)
+        msg = "MQTT (Paho) subscribed to topic '{}' (QoS={})".format(topic, qos)
         msg_type = PAYLOAD_CT.STATUS_TYPE.STATUS_NORMAL
       else:
         msg = "MQTT (Paho) subscribe to '{}' FAILED after {} retries (reason:{})".format(topic, max_retries, exception)
         msg_type = PAYLOAD_CT.STATUS_TYPE.STATUS_EXCEPTION
+        has_connection = False
+        failure_msg = msg
       # endif
+
+    if not has_connection:
+      msg = failure_msg
+      msg_type = PAYLOAD_CT.STATUS_TYPE.STATUS_EXCEPTION
 
     dct_ret = {
       'has_connection': has_connection,
@@ -420,15 +436,16 @@ class MQTTWrapper(BaseCommWrapper):
       return
 
     channel_def = self.get_send_channel_def(send_to=send_to)
+    qos = self.get_channel_qos(channel_def=channel_def)
 
     result = mqttc.publish(
       topic=channel_def[self.channel_key],
       payload=message,
-      qos=self.cfg_qos
+      qos=qos
     )
 
     ####
-    self.D("Sent message (QoS {})'{}'".format(self.cfg_qos, message))
+    self.D("Sent message (QoS {})'{}'".format(qos, message))
     ####
 
     if result.rc == mqtt.MQTT_ERR_QUEUE_SIZE:

--- a/tests/test_mqtt_channel_qos.py
+++ b/tests/test_mqtt_channel_qos.py
@@ -1,8 +1,11 @@
 import unittest
 import copy
+import pathlib
+import tomllib
 from collections import deque
 from unittest import mock
 
+import ratio1
 from ratio1.base.generic_session import GenericSession
 from ratio1.comm.mqtt_wrapper import MQTTWrapper
 from ratio1.const import COMMS
@@ -100,6 +103,13 @@ def _base_config():
 
 
 class TestMqttChannelQos(unittest.TestCase):
+
+  def test_package_metadata_version_matches_runtime_export(self):
+    pyproject_path = pathlib.Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as fh:
+      pyproject_data = tomllib.load(fh)
+
+    self.assertEqual(pyproject_data["project"]["version"], ratio1.__version__)
 
   def test_send_uses_channel_qos_when_available(self):
     wrapper = MQTTWrapper(

--- a/tests/test_mqtt_channel_qos.py
+++ b/tests/test_mqtt_channel_qos.py
@@ -1,0 +1,278 @@
+import unittest
+import copy
+from collections import deque
+from unittest import mock
+
+from ratio1.base.generic_session import GenericSession
+from ratio1.comm.mqtt_wrapper import MQTTWrapper
+from ratio1.const import COMMS
+from ratio1.const.payload import STATUS_TYPE
+
+
+class _FakeLog:
+  def __init__(self):
+    self.messages = []
+
+  def P(self, message, **kwargs):
+    self.messages.append((message, kwargs))
+    return
+
+  def get_unique_id(self):
+    return "testid"
+
+
+class _PublishResult:
+  rc = 0
+
+
+class _FakeMqttClient:
+  def __init__(self):
+    self.published = []
+    self.subscribed = []
+
+  def publish(self, topic, payload, qos):
+    self.published.append({
+      "topic": topic,
+      "payload": payload,
+      "qos": qos,
+    })
+    return _PublishResult()
+
+  def subscribe(self, topic, qos):
+    self.subscribed.append({
+      "topic": topic,
+      "qos": qos,
+    })
+    return (0, len(self.subscribed))
+
+
+class _FlakyMqttClient(_FakeMqttClient):
+  def __init__(self, failures_by_topic):
+    super().__init__()
+    self.failures_by_topic = dict(failures_by_topic)
+    self.attempts_by_topic = {}
+
+  def subscribe(self, topic, qos):
+    self.attempts_by_topic[topic] = self.attempts_by_topic.get(topic, 0) + 1
+    remaining_failures = self.failures_by_topic.get(topic, 0)
+    if remaining_failures > 0:
+      self.failures_by_topic[topic] = remaining_failures - 1
+      raise RuntimeError(f"transient subscribe failure for {topic}")
+    return super().subscribe(topic=topic, qos=qos)
+
+
+class _RcFailMqttClient(_FakeMqttClient):
+  def __init__(self, failures_by_topic):
+    super().__init__()
+    self.failures_by_topic = dict(failures_by_topic)
+    self.attempts_by_topic = {}
+
+  def subscribe(self, topic, qos):
+    self.attempts_by_topic[topic] = self.attempts_by_topic.get(topic, 0) + 1
+    remaining_failures = self.failures_by_topic.get(topic, 0)
+    if remaining_failures > 0:
+      self.failures_by_topic[topic] = remaining_failures - 1
+      return (1, self.attempts_by_topic[topic])
+    return super().subscribe(topic=topic, qos=qos)
+
+
+def _base_config():
+  return {
+    COMMS.HOST: "localhost",
+    COMMS.PORT: 1883,
+    COMMS.USER: "",
+    COMMS.PASS: "",
+    COMMS.EE_ADDR: "0xSELF",
+    COMMS.QOS: 0,
+    COMMS.SECURED: 0,
+    COMMS.COMMUNICATION_CONFIG_CHANNEL: {
+      COMMS.TOPIC: "root/{}/config",
+      COMMS.QOS: 2,
+    },
+    COMMS.COMMUNICATION_CTRL_CHANNEL: {
+      COMMS.TOPIC: "root/ctrl",
+      COMMS.QOS: 1,
+    },
+    COMMS.COMMUNICATION_PAYLOADS_CHANNEL: {
+      COMMS.TOPIC: "root/payloads",
+    },
+  }
+
+
+class TestMqttChannelQos(unittest.TestCase):
+
+  def test_send_uses_channel_qos_when_available(self):
+    wrapper = MQTTWrapper(
+      log=_FakeLog(),
+      config=_base_config(),
+      send_channel_name=COMMS.COMMUNICATION_CTRL_CHANNEL,
+      verbosity=99,
+    )
+    client = _FakeMqttClient()
+    wrapper._mqttc = client
+
+    wrapper.send("hb")
+
+    self.assertEqual(client.published[0]["topic"], "root/ctrl")
+    self.assertEqual(client.published[0]["qos"], 1)
+
+  def test_targeted_command_send_uses_config_channel_qos(self):
+    wrapper = MQTTWrapper(
+      log=_FakeLog(),
+      config=_base_config(),
+      send_channel_name=COMMS.COMMUNICATION_CONFIG_CHANNEL,
+      verbosity=99,
+    )
+    client = _FakeMqttClient()
+    wrapper._mqttc = client
+
+    wrapper.send("cmd", send_to="0xNODE")
+
+    self.assertEqual(client.published[0]["topic"], "root/0xNODE/config")
+    self.assertEqual(client.published[0]["qos"], 2)
+
+  def test_subscribe_uses_receive_channel_qos(self):
+    wrapper = MQTTWrapper(
+      log=_FakeLog(),
+      config=_base_config(),
+      recv_buff=deque(),
+      recv_channel_name=COMMS.COMMUNICATION_CONFIG_CHANNEL,
+      verbosity=99,
+    )
+    client = _FakeMqttClient()
+    wrapper._mqttc = client
+
+    result = wrapper.subscribe(max_retries=1)
+
+    self.assertTrue(result["has_connection"])
+    self.assertEqual(client.subscribed[0]["topic"], "root/0xSELF/config")
+    self.assertEqual(client.subscribed[0]["qos"], 2)
+
+  def test_subscribe_retries_are_per_topic(self):
+    config = _base_config()
+    config[COMMS.COMMUNICATION_PAYLOADS_CHANNEL][COMMS.TARGETED_TOPIC] = "root/{}/payloads"
+    wrapper = MQTTWrapper(
+      log=_FakeLog(),
+      config=config,
+      recv_buff=deque(),
+      recv_channel_name=COMMS.COMMUNICATION_PAYLOADS_CHANNEL,
+      verbosity=99,
+    )
+    client = _FlakyMqttClient({
+      "root/payloads": 2,
+      "root/0xSELF/payloads": 2,
+    })
+    wrapper._mqttc = client
+
+    with mock.patch("ratio1.comm.mqtt_wrapper.sleep", lambda _seconds: None):
+      result = wrapper.subscribe(max_retries=3)
+
+    self.assertTrue(result["has_connection"])
+    self.assertEqual(client.attempts_by_topic["root/payloads"], 3)
+    self.assertEqual(client.attempts_by_topic["root/0xSELF/payloads"], 3)
+    self.assertEqual([row["topic"] for row in client.subscribed], ["root/payloads", "root/0xSELF/payloads"])
+
+  def test_subscribe_retries_nonzero_paho_return_codes(self):
+    wrapper = MQTTWrapper(
+      log=_FakeLog(),
+      config=_base_config(),
+      recv_buff=deque(),
+      recv_channel_name=COMMS.COMMUNICATION_CONFIG_CHANNEL,
+      verbosity=99,
+    )
+    client = _RcFailMqttClient({"root/0xSELF/config": 2})
+    wrapper._mqttc = client
+
+    with mock.patch("ratio1.comm.mqtt_wrapper.sleep", lambda _seconds: None):
+      result = wrapper.subscribe(max_retries=3)
+
+    self.assertTrue(result["has_connection"])
+    self.assertEqual(client.attempts_by_topic["root/0xSELF/config"], 3)
+
+  def test_subscribe_partial_failure_keeps_exception_status(self):
+    config = _base_config()
+    config[COMMS.COMMUNICATION_PAYLOADS_CHANNEL][COMMS.TARGETED_TOPIC] = "root/{}/payloads"
+    wrapper = MQTTWrapper(
+      log=_FakeLog(),
+      config=config,
+      recv_buff=deque(),
+      recv_channel_name=COMMS.COMMUNICATION_PAYLOADS_CHANNEL,
+      verbosity=99,
+    )
+    client = _FlakyMqttClient({
+      "root/payloads": 2,
+    })
+    wrapper._mqttc = client
+
+    with mock.patch("ratio1.comm.mqtt_wrapper.sleep", lambda _seconds: None):
+      result = wrapper.subscribe(max_retries=2)
+
+    self.assertFalse(result["has_connection"])
+    self.assertEqual(result["msg_type"], STATUS_TYPE.STATUS_EXCEPTION)
+    self.assertIn("root/payloads", result["msg"])
+
+  def test_global_qos_is_fallback_for_channels_without_qos(self):
+    config = _base_config()
+    config[COMMS.QOS] = 1
+    wrapper = MQTTWrapper(
+      log=_FakeLog(),
+      config=config,
+      send_channel_name=COMMS.COMMUNICATION_PAYLOADS_CHANNEL,
+      verbosity=99,
+    )
+    client = _FakeMqttClient()
+    wrapper._mqttc = client
+
+    wrapper.send("payload")
+
+    self.assertEqual(client.published[0]["qos"], 1)
+
+  def test_channel_qos_does_not_require_global_fallback(self):
+    config = _base_config()
+    del config[COMMS.QOS]
+    wrapper = MQTTWrapper(
+      log=_FakeLog(),
+      config=config,
+      send_channel_name=COMMS.COMMUNICATION_CTRL_CHANNEL,
+      verbosity=99,
+    )
+    client = _FakeMqttClient()
+    wrapper._mqttc = client
+
+    wrapper.send("hb")
+
+    self.assertEqual(client.published[0]["qos"], 1)
+
+  def test_session_env_qos_populates_channel_config(self):
+    default_config = copy.deepcopy(GenericSession.default_config)
+    session = GenericSession.__new__(GenericSession)
+    session._config = copy.deepcopy(GenericSession.default_config)
+
+    with mock.patch.dict("os.environ", {
+      "EE_MQTT_HEARTBEAT_QOS": "1",
+      "EE_MQTT_COMMAND_QOS": "2",
+    }):
+      session._GenericSession__apply_channel_qos_from_env()
+
+    self.assertEqual(session._config[COMMS.COMMUNICATION_CTRL_CHANNEL][COMMS.QOS], 1)
+    self.assertEqual(session._config[COMMS.COMMUNICATION_CONFIG_CHANNEL][COMMS.QOS], 2)
+    self.assertEqual(GenericSession.default_config, default_config)
+
+  def test_subscribe_without_receive_channel_is_explicit_noop(self):
+    wrapper = MQTTWrapper(
+      log=_FakeLog(),
+      config=_base_config(),
+      verbosity=99,
+    )
+    client = _FakeMqttClient()
+    wrapper._mqttc = client
+
+    result = wrapper.subscribe(max_retries=1)
+
+    self.assertTrue(result["has_connection"])
+    self.assertIn("disabled", result["msg"])
+    self.assertEqual(client.subscribed, [])
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- Add channel-specific MQTT QoS selection for publish and subscribe paths.
- Apply `EE_MQTT_HEARTBEAT_QOS` and `EE_MQTT_COMMAND_QOS` to SDK session channel config without mutating shared defaults.
- Add regression coverage for channel QoS fallback, subscribe retry behavior, and receive-disabled no-op subscriptions.

## Why
This is the SDK side of ECOMMS-0001. It lets heartbeat and command/control channels use different MQTT delivery guarantees while preserving the existing global QoS fallback for unchanged configs.

## Verification
- `python3 -m compileall ratio1 tests/test_mqtt_channel_qos.py`: pass
- `/home/bleot/venvs/umbrella313/bin/python -m unittest tests.test_mqtt_channel_qos`: pass, 10 tests
- Initial `python3 -m unittest tests.test_mqtt_channel_qos`: blocked by system Python missing `numpy`; rerun passed with the project venv above.

## Related
- Paired core runtime communication PR: https://github.com/Ratio1/naeural_core/pull/207
- Paired edge validation/testbed PR: https://github.com/Ratio1/edge_node/pull/435