### PR TITLE
Resolve CSP escrow owner transfer events

### DIFF
--- a/ratio1/_ver.py
+++ b/ratio1/_ver.py
@@ -1,4 +1,4 @@
-__VER__ = "3.5.44"
+__VER__ = "3.5.45"
 
 if __name__ == "__main__":
   with open("pyproject.toml", "rt") as fd:

--- a/ratio1/bc/evm.py
+++ b/ratio1/bc/evm.py
@@ -36,6 +36,7 @@ Web3Vars = namedtuple(
 
 if not EE_VPN_IMPL:
   from web3 import Web3
+  from web3.logs import DISCARD
 else:
   class Web3:
     """
@@ -1655,6 +1656,90 @@ class _EVMMixin:
       )
       job_ids = [int(job.get("jobId")) for job in jobs if job.get("jobId") is not None]
       return job_ids
+
+    def web3_get_csp_escrow_owner(self, escrow_address: str, network: str = None):
+      """
+      Retrieve the current owner for a CSP escrow from PoAI Manager.
+      """
+      assert self.is_valid_eth_address(escrow_address), "Invalid escrow address"
+
+      w3vars = self._get_web3_vars(network)
+      contract = w3vars.w3.eth.contract(
+        address=w3vars.poai_manager_address,
+        abi=EVM_ABI_DATA.POAI_MANAGER_ABI,
+      )
+      owner = contract.functions.escrowToOwner(escrow_address).call()
+      return to_checksum_address(owner)
+
+    def web3_get_csp_escrow_owner_transfer_from_tx(
+      self,
+      tx_hash: str,
+      log_index: int = None,
+      network: str = None,
+    ):
+      """
+      Resolve and validate a CSP escrow owner transfer event from a mined tx.
+      """
+      if not isinstance(tx_hash, str) or not tx_hash.startswith("0x"):
+        raise ValueError("Invalid transaction hash")
+      if log_index is not None:
+        log_index = int(log_index)
+
+      w3vars = self._get_web3_vars(network)
+      contract = w3vars.w3.eth.contract(
+        address=w3vars.poai_manager_address,
+        abi=EVM_ABI_DATA.POAI_MANAGER_ABI,
+      )
+      receipt = w3vars.w3.eth.get_transaction_receipt(tx_hash)
+      receipt_status = getattr(receipt, "status", receipt.get("status", None))
+      if receipt_status != 1:
+        raise ValueError(f"Transaction {tx_hash} did not succeed")
+
+      manager_address = to_checksum_address(w3vars.poai_manager_address)
+      matching_logs = []
+      decoded_logs = contract.events.CspEscrowOwnerTransferred().process_receipt(
+        receipt,
+        errors=DISCARD,
+      )
+      for event_log in decoded_logs:
+        event_address = to_checksum_address(event_log["address"])
+        if event_address != manager_address:
+          continue
+        event_log_index = int(event_log["logIndex"])
+        if log_index is not None and event_log_index != log_index:
+          continue
+        matching_logs.append(event_log)
+
+      if len(matching_logs) == 0:
+        raise ValueError("No CspEscrowOwnerTransferred event found in transaction")
+      if log_index is None and len(matching_logs) > 1:
+        raise ValueError("Multiple CspEscrowOwnerTransferred events found; provide log_index")
+
+      event_log = matching_logs[0]
+      args = event_log["args"]
+      escrow = to_checksum_address(args["escrow"])
+      old_owner = to_checksum_address(args["oldOwner"])
+      new_owner = to_checksum_address(args["newOwner"])
+
+      current_owner = self.web3_get_csp_escrow_owner(
+        escrow_address=escrow,
+        network=w3vars.network,
+      )
+      if current_owner.lower() != new_owner.lower():
+        raise ValueError(
+          f"Escrow {escrow} is currently owned by {current_owner}, not transfer recipient {new_owner}"
+        )
+
+      block_number = getattr(receipt, "blockNumber", receipt.get("blockNumber", None))
+      return {
+        "network": w3vars.network,
+        "tx_hash": tx_hash,
+        "log_index": int(event_log["logIndex"]),
+        "block_number": int(block_number) if block_number is not None else None,
+        "escrow": escrow,
+        "old_owner": old_owner,
+        "new_owner": new_owner,
+      }
 
     def web3_submit_node_update(
       self,

--- a/ratio1/const/evm_net.py
+++ b/ratio1/const/evm_net.py
@@ -291,6 +291,50 @@ _ERC20_ABI = [
 
 _POAI_MANAGER_ABI = [
   {
+    "anonymous": False,
+    "inputs": [
+      {
+        "indexed": True,
+        "internalType": "address",
+        "name": "escrow",
+        "type": "address"
+      },
+      {
+        "indexed": True,
+        "internalType": "address",
+        "name": "oldOwner",
+        "type": "address"
+      },
+      {
+        "indexed": True,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "CspEscrowOwnerTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "escrowToOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",

--- a/tests/test_csp_escrow_owner_transfer_event.py
+++ b/tests/test_csp_escrow_owner_transfer_event.py
@@ -1,0 +1,101 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from web3 import Web3
+
+from ratio1.bc.evm import _EVMMixin
+
+
+class _DummyEngine(_EVMMixin):
+  def __init__(self):
+    self.messages = []
+
+  def P(self, message, **kwargs):
+    self.messages.append(message)
+
+
+class TestCspEscrowOwnerTransferEvent(unittest.TestCase):
+
+  def setUp(self):
+    self.engine = _DummyEngine()
+    self.manager = Web3.to_checksum_address("0x" + "11" * 20)
+    self.escrow = Web3.to_checksum_address("0x" + "22" * 20)
+    self.old_owner = Web3.to_checksum_address("0x" + "33" * 20)
+    self.new_owner = Web3.to_checksum_address("0x" + "44" * 20)
+    self.contract = mock.Mock()
+    self.web3 = mock.Mock()
+    self.web3.eth.contract.return_value = self.contract
+    self.web3.eth.get_transaction_receipt.return_value = {
+      "status": 1,
+      "blockNumber": 123,
+    }
+    self.web3_vars = SimpleNamespace(
+      w3=self.web3,
+      rpc_url="http://rpc.local",
+      network="devnet",
+      poai_manager_address=self.manager,
+    )
+    self.engine._get_web3_vars = mock.Mock(return_value=self.web3_vars)
+    self.contract.functions.escrowToOwner.return_value.call.return_value = self.new_owner
+
+  def _event(self, log_index=7, address=None):
+    return {
+      "address": address or self.manager,
+      "logIndex": log_index,
+      "args": {
+        "escrow": self.escrow,
+        "oldOwner": self.old_owner,
+        "newOwner": self.new_owner,
+      },
+    }
+
+  def _set_events(self, events):
+    event_filter = mock.Mock()
+    event_filter.process_receipt.return_value = events
+    self.contract.events.CspEscrowOwnerTransferred.return_value = event_filter
+
+  def test_resolves_valid_transfer_event_and_confirms_current_owner(self):
+    self._set_events([self._event()])
+
+    result = self.engine.web3_get_csp_escrow_owner_transfer_from_tx("0xabc")
+
+    self.assertEqual(result["network"], "devnet")
+    self.assertEqual(result["tx_hash"], "0xabc")
+    self.assertEqual(result["log_index"], 7)
+    self.assertEqual(result["block_number"], 123)
+    self.assertEqual(result["escrow"], self.escrow)
+    self.assertEqual(result["old_owner"], self.old_owner)
+    self.assertEqual(result["new_owner"], self.new_owner)
+    self.contract.functions.escrowToOwner.assert_called_once_with(self.escrow)
+
+  def test_requires_log_index_when_transaction_has_multiple_transfer_events(self):
+    self._set_events([self._event(log_index=7), self._event(log_index=8)])
+
+    with self.assertRaisesRegex(ValueError, "Multiple"):
+      self.engine.web3_get_csp_escrow_owner_transfer_from_tx("0xabc")
+
+  def test_uses_requested_log_index(self):
+    self._set_events([self._event(log_index=7), self._event(log_index=8)])
+
+    result = self.engine.web3_get_csp_escrow_owner_transfer_from_tx("0xabc", log_index=8)
+
+    self.assertEqual(result["log_index"], 8)
+
+  def test_rejects_failed_transaction_receipt(self):
+    self.web3.eth.get_transaction_receipt.return_value = {"status": 0}
+    self._set_events([self._event()])
+
+    with self.assertRaisesRegex(ValueError, "did not succeed"):
+      self.engine.web3_get_csp_escrow_owner_transfer_from_tx("0xabc")
+
+  def test_rejects_transfer_event_when_current_owner_no_longer_matches(self):
+    self.contract.functions.escrowToOwner.return_value.call.return_value = self.old_owner
+    self._set_events([self._event()])
+
+    with self.assertRaisesRegex(ValueError, "currently owned"):
+      self.engine.web3_get_csp_escrow_owner_transfer_from_tx("0xabc")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- add PoAI Manager ABI support for CspEscrowOwnerTransferred and escrowToOwner
- add a read-only resolver that validates a mined transfer tx/log against current chain ownership
- cover event resolution, ambiguous logs, failed receipts, and stale current-owner state

## Tests
- PYTHONPATH=/Users/alessandro/programmazione/ratio1/ratio1_sdk /Users/alessandro/.pyenv/versions/3.12.3/bin/python -m unittest tests.test_csp_escrow_owner_transfer_event
- PYTHONPATH=/Users/alessandro/programmazione/ratio1/ratio1_sdk /Users/alessandro/.pyenv/versions/3.12.3/bin/python -m compileall ratio1