### PR TITLE
Add r1ctl node grouping

### DIFF
--- a/r1ctl.MD
+++ b/r1ctl.MD
@@ -50,6 +50,8 @@ Retrieve information about network nodes.
 - `--peered`: Get only peered nodes - ie the nodes that allow the current client to connect to them and give them workloads
 - `--supervisor="addr"`: Query nodes using a specific supervisor address.
 - `--eth`: Use ETH addresses instead of the default Ratio1 addresses.
+- `--group-by[=field]`: Group nodes by a selected field. Omit the field to choose from an interactive menu.
+- `--explicit`: When used with `--group-by`, show the node aliases and addresses below each group.
 
 **Examples**:
 ```bash
@@ -58,6 +60,15 @@ nepctl get nodes --all
 
 # Get online nodes using a specific supervisor:
 nepctl get nodes --online --supervisor="Amfnbt3N-qg2-qGtywZIPQBTVlAnoADVRmSAsdDhlQ-6"
+
+# Choose a field interactively and group nodes by it:
+r1ctl get nodes --group-by
+
+# Group nodes directly by version:
+r1ctl get nodes --group-by=Version
+
+# Group nodes by version and show the nodes in each group:
+r1ctl get nodes --group-by=Version --explicit
 ```
 
 #### Using ETH addresses

--- a/ratio1/_ver.py
+++ b/ratio1/_ver.py
@@ -1,4 +1,4 @@
-__VER__ = "3.5.44"
+__VER__ = "3.5.45"
 
 if __name__ == "__main__":
   with open("pyproject.toml", "rt") as fd:

--- a/ratio1/cli/cli.py
+++ b/ratio1/cli/cli.py
@@ -36,6 +36,33 @@ def create_global_parser():
   )
   return global_parser
 
+def add_cli_param(parser, param, desc):
+  """
+  Add one CLI parameter to an argparse parser from a CLI_COMMANDS entry.
+
+  Parameters
+  ----------
+  parser : argparse.ArgumentParser
+      Parser that receives the argument definition.
+  param : str
+      Argument name, either optional (``--name``) or positional.
+  desc : str
+      Human-readable help text. Optional arguments ending in ``(flag)`` become
+      booleans, and optional arguments ending in ``(optional)`` can be provided
+      with or without a value.
+  """
+  if param.startswith("--"):
+    desc_lower = desc.lower()
+    if desc_lower.endswith("(flag)"):
+      parser.add_argument(param, action="store_true", help=desc)
+    elif desc_lower.endswith("(optional)"):
+      parser.add_argument(param, nargs="?", const="", type=str, help=desc)
+    else:
+      parser.add_argument(param, type=str, help=desc)
+  else:
+    parser.add_argument(param, help=desc)
+  return
+
 def build_parser():
   """
   Dynamically builds the argument parser based on CLI_COMMANDS.
@@ -75,14 +102,7 @@ def build_parser():
         # If we have parameters, add them
         if isinstance(subcmd_info, dict) and "params" in subcmd_info:
           for param, desc in subcmd_info["params"].items():
-            if param.startswith("--"):
-              if desc.lower().endswith("(flag)"):
-                subcommand_parser.add_argument(param, action="store_true", help=desc)
-              else:
-                subcommand_parser.add_argument(param, type=str, help=desc)
-            else:
-              # Positional argument
-              subcommand_parser.add_argument(param, help=desc)
+            add_cli_param(subcommand_parser, param, desc)
 
         # Assign the function to call
         subcommand_parser.set_defaults(func=subcmd_info["func"])
@@ -90,13 +110,7 @@ def build_parser():
       # Single-level command with optional parameters
       if "params" in subcommands:
         for param, desc in subcommands["params"].items():
-          if param.startswith("--"):
-            if desc.lower().endswith("(flag)"):
-              command_parser.add_argument(param, action="store_true", help=desc)
-            else:
-              command_parser.add_argument(param, type=str, help=desc)
-          else:
-            command_parser.add_argument(param, help=desc)
+          add_cli_param(command_parser, param, desc)
 
       # Set the function to be called for this command
       command_parser.set_defaults(func=subcommands["func"])

--- a/ratio1/cli/cli_commands.py
+++ b/ratio1/cli/cli_commands.py
@@ -37,6 +37,8 @@ CLI_COMMANDS = {
                 "--alias" : "Use a specific node alias filter",
                 "--eth" : "Use a specific node (flag)",
                 "--wide" : "Display all available information (flag)",
+                "--group-by": "Group nodes by a selected field; omit the value to choose from an interactive menu (optional)",
+                "--explicit": "Show node aliases and addresses in grouped output (flag)",
             }
         },
         "supervisors": {

--- a/ratio1/cli/nodes.py
+++ b/ratio1/cli/nodes.py
@@ -1,5 +1,6 @@
 import os
 import json
+import sys
 
 from time import time
 from ratio1.utils.config import log_with_color
@@ -8,6 +9,8 @@ from ratio1._ver import __VER__ as version
 
 from pandas import DataFrame
 from datetime import datetime
+
+GROUP_BY_LIST_VALUE = ""
 
 
 def _get_netstats(
@@ -51,6 +54,168 @@ def _get_netstats(
   return df, supervisor, super_alias, nr_supers, elapsed
 
 
+def _resolve_group_by_column(df, group_by):
+  """
+  Resolve a user-provided group-by field to a DataFrame column name.
+
+  Parameters
+  ----------
+  df : pandas.DataFrame
+      Node report returned by ``Session.get_network_known_nodes``.
+  group_by : str
+      User-provided field name from ``r1ctl get nodes --group-by``.
+
+  Returns
+  -------
+  str or None
+      Matching DataFrame column name, or ``None`` if no column matches.
+  """
+  normalized = str(group_by).strip().lower()
+  for column in df.columns:
+    if column.lower() == normalized:
+      return column
+  return None
+
+
+def _show_group_by_fields(df):
+  """
+  Print the fields that can be used with ``r1ctl get nodes --group-by``.
+
+  Parameters
+  ----------
+  df : pandas.DataFrame
+      Node report whose columns define the groupable fields.
+  """
+  fields = "\n".join(f"  - {column}" for column in df.columns)
+  log_with_color("Available fields for `r1ctl get nodes --group-by <field>`:", color='b')
+  log_with_color(fields)
+  return
+
+
+def _select_group_by_column(df):
+  """
+  Ask the user to select a group-by field from the node report columns.
+
+  Parameters
+  ----------
+  df : pandas.DataFrame
+      Node report whose columns define the groupable fields.
+
+  Returns
+  -------
+  str or None
+      Selected DataFrame column name, or ``None`` if no usable selection is
+      available.
+  """
+  columns = list(df.columns)
+  if not columns:
+    log_with_color("No fields are available for grouping.", color='r')
+    return None
+
+  log_with_color("Select a field to group nodes by:", color='b')
+  for index, column in enumerate(columns, start=1):
+    log_with_color(f"  {index}. {column}")
+
+  if not sys.stdin.isatty():
+    log_with_color(
+      "No interactive terminal is available. Use `--group-by=<field>` instead.",
+      color='r'
+    )
+    return None
+
+  selection = input("Group by field number or name: ").strip()
+  if not selection:
+    return None
+
+  if selection.isdigit():
+    selected_index = int(selection)
+    if 1 <= selected_index <= len(columns):
+      return columns[selected_index - 1]
+    log_with_color(f"Invalid selection '{selection}'.", color='r')
+    return None
+
+  selected_column = _resolve_group_by_column(df, selection)
+  if selected_column is None:
+    log_with_color(f"Unknown group-by field '{selection}'.", color='r')
+  return selected_column
+
+
+def _get_grouped_nodes(df, column, explicit=False):
+  """
+  Count nodes by unique values in one DataFrame column.
+
+  Parameters
+  ----------
+  df : pandas.DataFrame
+      Node report to aggregate.
+  column : str
+      Column name to group by.
+  explicit : bool, optional
+      If True, include the node aliases and addresses that belong to each
+      group. Defaults to False.
+
+  Returns
+  -------
+  pandas.DataFrame
+      Summary containing the grouped value, node count, and optionally node
+      identities.
+  """
+  groupable_df = df[[column]].copy()
+  if explicit:
+    explicit_columns = [c for c in ["Alias", "Address"] if c in df.columns]
+    groupable_df = df[[column, *explicit_columns]].copy()
+  groupable_df[column] = groupable_df[column].fillna("[missing]").replace("", "[empty]")
+  groupby_obj = groupable_df.groupby(column, dropna=False)
+  grouped_df = groupby_obj.size().reset_index(name="Nodes")
+  if explicit:
+    if "Alias" in groupable_df.columns:
+      grouped_df["Node Aliases"] = groupby_obj["Alias"].apply(
+        lambda values: ", ".join(str(v) for v in values if v is not None)
+      ).values
+    if "Address" in groupable_df.columns:
+      grouped_df["Node Addresses"] = groupby_obj["Address"].apply(
+        lambda values: ", ".join(str(v) for v in values if v is not None)
+      ).values
+  grouped_df["_sort_value"] = grouped_df[column].astype(str)
+  grouped_df = grouped_df.sort_values(
+    by=["Nodes", "_sort_value"],
+    ascending=[False, True]
+  )
+  grouped_df = grouped_df.drop(columns=["_sort_value"]).reset_index(drop=True)
+  return grouped_df
+
+
+def _format_explicit_grouped_nodes(df, column):
+  """
+  Format grouped nodes as readable multi-line text.
+
+  Parameters
+  ----------
+  df : pandas.DataFrame
+      Node report to aggregate and display.
+  column : str
+      Column name to group by.
+
+  Returns
+  -------
+  str
+      Human-readable grouped node listing. Each group starts with the grouped
+      field value and count, followed by indented node entries.
+  """
+  display_df = df[[column, "Alias", "Address"]].copy()
+  display_df[column] = display_df[column].fillna("[missing]").replace("", "[empty]")
+  grouped_df = _get_grouped_nodes(df, column)
+  lines = []
+  for _, group_row in grouped_df.iterrows():
+    group_value = group_row[column]
+    group_count = group_row["Nodes"]
+    node_label = "node" if group_count == 1 else "nodes"
+    lines.append(f"{column}: {group_value} ({group_count} {node_label})")
+    group_nodes = display_df[display_df[column] == group_value]
+    for _, node_row in group_nodes.iterrows():
+      lines.append(f"  - {node_row['Alias']}  {node_row['Address']}")
+  return "\n".join(lines)
+
 
 def get_nodes(args):
   """
@@ -63,6 +228,8 @@ def get_nodes(args):
   """
   supervisor_addr = args.supervisor
   alias_filter = args.alias
+  group_by = getattr(args, "group_by", None)
+  explicit = getattr(args, "explicit", False)
   online = args.online
   online = True # always online, flag deprecated
   wide = args.wide
@@ -84,6 +251,7 @@ def get_nodes(args):
     FILTERED = ['State']
     df = df[[c for c in df.columns if c not in FILTERED]]
 
+  grouping_requested = group_by is not None
   prefix = "Online n" if (online or args.peered) else "N"
   # network = os.environ.get(BASE_CT.dAuth.DAUTH_NET_ENV_KEY, BASE_CT.dAuth.DAUTH_SDK_NET_DEFAULT)
   network = sess.bc_engine.evm_network
@@ -99,7 +267,27 @@ def get_nodes(args):
     )
     import pandas as pd
     pd.set_option('display.float_format', '{:.4f}'.format)
-    log_with_color(f"{df}\n")    
+    if grouping_requested:
+      if group_by == GROUP_BY_LIST_VALUE:
+        column = _select_group_by_column(df)
+        if column is None:
+          return df
+      else:
+        column = _resolve_group_by_column(df, group_by)
+        if column is None:
+          log_with_color(f"Unknown group-by field '{group_by}'.", color='r')
+          _show_group_by_fields(df)
+          return df
+
+      grouped_df = _get_grouped_nodes(df, column, explicit=explicit)
+      log_with_color(f"Nodes grouped by '{column}':", color='b')
+      if explicit:
+        log_with_color(f"{_format_explicit_grouped_nodes(df, column)}\n")
+      else:
+        log_with_color(f"{grouped_df}\n")
+      return grouped_df
+
+    log_with_color(f"{df}\n")
   return df
   
   


### PR DESCRIPTION
## What changed

- Added `--group-by` to `r1ctl get nodes`, supporting both direct values such as `--group-by=Version` and bare interactive selection with `--group-by`.
- Added `--explicit` for grouped node output, displaying grouped nodes in a readable nested layout.
- Extended the CLI registry parser so optional-valued parameters can be represented in `CLI_COMMANDS`.
- Updated `r1ctl.MD` with usage examples.

## Why

Operators need a compact way to summarize fleet properties such as node versions, while still being able to inspect the actual nodes in each group when needed.

## Validation

- `python3 -m compileall ratio1`
- `git diff --check`
- Ephemeral Docker container parser and grouping tests with mocked netstats data
- Real testnet container calls:
  - `r1ctl get nodes --group-by=Version`
  - `r1ctl get nodes --group-by=Version --explicit`

## Notes

The real testnet call used a copied container-local `~/.ratio1` config set to `testnet`; host config was not mutated.