### PR TITLE
fix: honor R1FS JSON log suppression

### DIFF
--- a/ratio1/_ver.py
+++ b/ratio1/_ver.py
@@ -1,4 +1,4 @@
-__VER__ = "3.5.47"
+__VER__ = "3.5.48"
 
 if __name__ == "__main__":
   with open("pyproject.toml", "rt") as fd:

--- a/ratio1/ipfs/r1fs.py
+++ b/ratio1/ipfs/r1fs.py
@@ -1944,7 +1944,8 @@ class R1FSEngine:
       unique_dir = None
       try:
         json_data = json.dumps(data, sort_keys=True, separators=(',', ':'))
-        self.P(f"JSON data: {json_data}")
+        if show_logs:
+          self.P(f"JSON data: {json_data}")
         
         if use_tempfile:
           if show_logs:
@@ -3633,7 +3634,8 @@ class R1FSEngine:
       except (TypeError, ValueError) as e:
         raise ValueError(f"Data cannot be JSON serialized: {e}")
       
-      self.P(f"JSON data: {json_data}")
+      if show_logs:
+        self.P(f"JSON data: {json_data}")
 
       # Use custom filename or default
       if fn is None:
@@ -3661,7 +3663,7 @@ class R1FSEngine:
           file_path=tmp_json_path,
           nonce=nonce,
           secret=secret,
-          show_logs=True  # Don't show logs from calculate_file_cid
+          show_logs=show_logs,
         )
         
         if show_logs:

--- a/tests/test_r1fs_show_logs.py
+++ b/tests/test_r1fs_show_logs.py
@@ -1,0 +1,57 @@
+import unittest
+
+from ratio1.ipfs.r1fs import R1FSEngine
+
+
+class R1FSShowLogsTests(unittest.TestCase):
+
+  def _engine(self):
+    engine = object.__new__(R1FSEngine)
+    engine.messages = []
+    engine.debug_messages = []
+    engine.add_file_show_logs = []
+    engine.calculate_file_cid_show_logs = []
+
+    def P(message, *args, **kwargs):
+      engine.messages.append(str(message))
+
+    def Pd(message, *args, **kwargs):
+      engine.debug_messages.append(str(message))
+
+    def add_file(**kwargs):
+      engine.add_file_show_logs.append(kwargs.get("show_logs"))
+      return "cid"
+
+    def calculate_file_cid(**kwargs):
+      engine.calculate_file_cid_show_logs.append(kwargs.get("show_logs"))
+      return "cid"
+
+    engine.P = P
+    engine.Pd = Pd
+    engine.add_file = add_file
+    engine.calculate_file_cid = calculate_file_cid
+    return engine
+
+  def test_add_json_suppresses_raw_json_when_show_logs_false(self):
+    engine = self._engine()
+
+    cid = engine.add_json({"CRDB_PASSWORD": "secret"}, nonce=1, show_logs=False)
+
+    self.assertEqual(cid, "cid")
+    self.assertEqual(engine.add_file_show_logs, [False])
+    self.assertEqual(engine.messages, [])
+    self.assertEqual(engine.debug_messages, [])
+
+  def test_calculate_json_cid_suppresses_raw_json_when_show_logs_false(self):
+    engine = self._engine()
+
+    cid = engine.calculate_json_cid({"CRDB_PASSWORD": "secret"}, nonce=1, show_logs=False)
+
+    self.assertEqual(cid, "cid")
+    self.assertEqual(engine.calculate_file_cid_show_logs, [False])
+    self.assertEqual(engine.messages, [])
+    self.assertEqual(engine.debug_messages, [])
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- gate raw JSON R1FS logging behind `show_logs`
- propagate `show_logs` from JSON CID calculation into file CID calculation
- add regression tests proving raw JSON payloads are not printed when logs are disabled

## Verification
- `PYTHONPATH=/mnt/c/workspaces/r1_wrapper/worktrees/crdb-r1fs-log-redaction-naeural_client /tmp/crdb-edge-test-venv/bin/python -m unittest tests.test_r1fs_show_logs`
- `PYTHONPATH=/mnt/c/workspaces/r1_wrapper/worktrees/crdb-r1fs-log-redaction-naeural_client /tmp/crdb-edge-test-venv/bin/python -m compileall ratio1`
- `git diff --check`

## Notes
- Needed by the edge CockroachDB PR so Deeploy pipeline persistence can call R1FS with `show_logs=False` without lower-level raw JSON output.
