### PR TITLE
fix: use uv for pip-free r1ctl updates

### DIFF
--- a/ratio1/_ver.py
+++ b/ratio1/_ver.py
@@ -1,4 +1,4 @@
-__VER__ = "3.5.50"
+__VER__ = "3.5.51"
 
 if __name__ == "__main__":
   with open("pyproject.toml", "rt") as fd:

--- a/ratio1/cli/package_update.py
+++ b/ratio1/cli/package_update.py
@@ -3,6 +3,9 @@ import subprocess
 import os
 import sys
 import platform
+from importlib.util import find_spec
+from pathlib import Path
+from shutil import which
 from ratio1.utils.config import log_with_color
 
 
@@ -35,13 +38,53 @@ def _fresh_version(dist: str) -> str:
     return "unknown"
 
 
+def _update_command(pkg_name: str) -> list[str]:
+  """
+  Build the package-manager command for the active Python environment.
+
+  Parameters
+  ----------
+  pkg_name : str
+      Distribution name to upgrade.
+
+  Returns
+  -------
+  list[str]
+      A command that upgrades ``pkg_name`` in ``sys.executable``'s environment.
+
+  Notes
+  -----
+  ``uv venv --no-pip`` environments intentionally omit the ``pip`` module.
+  When ``uv`` is available in such an environment, target the running
+  interpreter explicitly instead of invoking ``python -m pip``.
+  """
+  if find_spec("pip") is None:
+    uv = which("uv")
+    if uv is None:
+      uv_name = "uv.exe" if os.name == "nt" else "uv"
+      local_uv = Path(sys.prefix) / ("Scripts" if os.name == "nt" else "bin") / uv_name
+      if local_uv.is_file():
+        uv = str(local_uv)
+    if uv is not None:
+      return [uv, "pip", "install", "--python", sys.executable, "--upgrade", pkg_name]
+
+  return [sys.executable, "-m", "pip", "install", "--upgrade", pkg_name]
+
+
 def update_package(args) -> None:
   """
-  Update the package in-place using pip.
-  This can be run through
-  ```
-  r1ctl update
-  ```
+  Update the package in-place using the available environment package manager.
+
+  Parameters
+  ----------
+  args : argparse.Namespace
+      Parsed CLI arguments. ``quiet`` controls installer output forwarding.
+
+  Notes
+  -----
+  This is invoked by ``r1ctl update``. The Windows branch starts a replacement
+  interpreter because the installed executable is locked until this process
+  exits.
   """
   pkg_name = _dist_name()
   initial_version = _local_version(pkg_name)
@@ -55,15 +98,15 @@ def update_package(args) -> None:
       "import subprocess",
       "import sys",
       "import importlib.metadata as m",
+      "from ratio1.cli.package_update import _update_command",
       f"pkg = '{pkg_name}'",
       f"quiet = {quiet}",
       f"initial_version = '{initial_version}'",
-      "pip = ['-qq'] if quiet else []",
       f"print('Windows detected, running update in a new process...')",
       # The following line is a single line of code, no leading spaces
       # it is split into multiple lines for readability.
       "code = subprocess.call("
-      "[sys.executable, '-m', 'pip', 'install', '--upgrade', pkg, *pip],"
+      "_update_command(pkg),"
       "stdout=subprocess.DEVNULL if quiet else None,"
       "stderr=subprocess.DEVNULL if quiet else None"
       ")",
@@ -79,11 +122,11 @@ def update_package(args) -> None:
       f"print(r'{cwd}>', end='')",
     ]
 
-    wrapper_code = f"\"{'; '.join(wrapper_code_lines)}\""
+    wrapper_code = '; '.join(wrapper_code_lines)
     os.execv(sys.executable, [sys.executable, "-c", wrapper_code])  # never returns
   # endif Windows
 
-  cmd = [sys.executable, "-m", "pip", "install", "--upgrade", pkg_name]
+  cmd = _update_command(pkg_name)
 
   # Inherit or suppress output based on `quiet`
   stdout = subprocess.DEVNULL if quiet else None

--- a/tests/test_package_update.py
+++ b/tests/test_package_update.py
@@ -1,0 +1,91 @@
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from ratio1.cli import package_update
+
+
+class PackageUpdateCommandTests(unittest.TestCase):
+  """Verify package-manager selection for the r1ctl update command."""
+
+  def test_uses_uv_when_pip_is_unavailable(self):
+    """
+    Select ``uv pip`` for a pip-free environment that has uv installed.
+
+    The active interpreter is passed to uv so the update cannot target a
+    different environment merely because a different virtualenv is active.
+    """
+    with patch.object(package_update, "find_spec", return_value=None), \
+         patch.object(package_update, "which", return_value="/usr/local/bin/uv"):
+      command = package_update._update_command("ratio1")
+
+    self.assertEqual(
+      command,
+      [
+        "/usr/local/bin/uv", "pip", "install", "--python", sys.executable,
+        "--upgrade", "ratio1",
+      ],
+    )
+
+  def test_uses_pip_when_the_active_environment_has_pip(self):
+    """Keep the existing pip command for environments that provide pip."""
+    with patch.object(package_update, "find_spec", return_value=object()), \
+         patch.object(package_update, "which") as which:
+      command = package_update._update_command("ratio1")
+
+    which.assert_not_called()
+    self.assertEqual(
+      command,
+      [sys.executable, "-m", "pip", "install", "--upgrade", "ratio1"],
+    )
+
+  def test_uses_uv_beside_the_active_interpreter_when_not_on_path(self):
+    """Find uv in the active virtualenv for absolute-path CLI invocations."""
+    with patch.object(package_update, "find_spec", return_value=None), \
+         patch.object(package_update, "which", return_value=None), \
+         patch.object(package_update.sys, "prefix", "/venv"), \
+         patch.object(package_update.Path, "is_file", return_value=True):
+      command = package_update._update_command("ratio1")
+
+    expected_uv = package_update.Path("/venv") / (
+      "Scripts" if package_update.os.name == "nt" else "bin"
+    ) / ("uv.exe" if package_update.os.name == "nt" else "uv")
+    self.assertEqual(command[0], str(expected_uv))
+
+  def test_falls_back_to_the_existing_pip_command_without_uv(self):
+    """Preserve the existing failure behavior when neither installer exists."""
+    with patch.object(package_update, "find_spec", return_value=None), \
+         patch.object(package_update, "which", return_value=None):
+      command = package_update._update_command("ratio1")
+
+    self.assertEqual(
+      command,
+      [sys.executable, "-m", "pip", "install", "--upgrade", "ratio1"],
+    )
+
+  def test_windows_updater_uses_the_shared_command_selection(self):
+    """Execute the deferred Windows updater through the shared installer path."""
+    args = SimpleNamespace(quiet=True)
+    with patch.object(package_update.platform, "system", return_value="Windows"), \
+         patch.object(package_update, "_dist_name", return_value="ratio1"), \
+         patch.object(package_update, "_local_version", return_value="1.0.0"), \
+         patch.object(package_update, "log_with_color"), \
+         patch.object(package_update.os, "execv", side_effect=RuntimeError("stop")) as execv:
+      with self.assertRaisesRegex(RuntimeError, "stop"):
+        package_update.update_package(args)
+
+    wrapper_code = execv.call_args.args[1][2]
+    self.assertIn("from ratio1.cli.package_update import _update_command", wrapper_code)
+    self.assertIn("subprocess.call(_update_command(pkg)", wrapper_code)
+    self.assertNotIn("'-m', 'pip'", wrapper_code)
+    with patch.object(package_update, "_update_command", return_value=["uv", "pip"]), \
+         patch("subprocess.call", return_value=0) as call, \
+         patch("importlib.metadata.version", return_value="1.0.0"):
+      exec(wrapper_code, {})
+
+    call.assert_called_once_with(
+      ["uv", "pip"],
+      stdout=package_update.subprocess.DEVNULL,
+      stderr=package_update.subprocess.DEVNULL,
+    )


### PR DESCRIPTION
## Summary
- select `uv pip` for `r1ctl update` when the active environment has no `pip` module
- target the running interpreter and retain the existing pip path otherwise
- fix and exercise the Windows deferred updater path

## Validation
- Docker: created `uv venv --no-pip`, installed this branch, ran `r1ctl update --quiet`, and confirmed `pip` remained unavailable
- Docker: `python -m unittest tests/test_package_update.py` (5 tests)
- Docker: `python -m compileall -q ratio1`

## Risk
- Native Windows execution was not run; the generated deferred updater is executed under mocks in the focused test.